### PR TITLE
relocated api get for external user

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -64,7 +64,7 @@ export default {
 
     this.setLoading(true);
     await this.getJwtToken()
-      .then(() =>
+      .then(() => {
         Promise.all([
           this.getUserInfo(),
           this.getActiveSchoolYear(),
@@ -73,8 +73,10 @@ export default {
           this.getSchoolAuthority(),
           this.getApplicationPickLists(),
           this.getApplicationMultiPickLists(),
-        ])
-      )
+        ]).then(() => {
+          this.getExternalContact();
+        });
+      })
       .catch((e) => {
         if (!e.response || e.response.status !== HttpStatus.UNAUTHORIZED) {
           this.logout();
@@ -96,6 +98,7 @@ export default {
       'getJwtToken',
       'getUserInfo',
       'logout',
+      'getExternalContact',
     ]),
     ...mapActions(metaDataStore, [
       'getActiveSchoolYear',

--- a/frontend/src/components/ModalIdle.vue
+++ b/frontend/src/components/ModalIdle.vue
@@ -31,7 +31,6 @@ export default {
   watch: {
     timer: {
       handler(val) {
-        console.log('countdown', val);
         if (val === 0) {
           this.handleIdleDialog();
         }

--- a/frontend/src/components/ModalIdle.vue
+++ b/frontend/src/components/ModalIdle.vue
@@ -107,7 +107,9 @@ export default {
     },
   },
   beforeUnmount() {
-    this.countdownWorker.terminate();
+    if (this.countdownWorker) {
+      this.countdownWorker.terminate();
+    }
   },
 };
 </script>

--- a/frontend/src/store/modules/auth.js
+++ b/frontend/src/store/modules/auth.js
@@ -77,13 +77,13 @@ export const authStore = defineStore('auth', {
     },
     async getUserInfo() {
       const userInfoRes = await ApiService.getUserInfo();
-      if (userInfoRes?.data.userId) {
-        const dynamicsContact = await ApiService.getContactByExternalId(
-          userInfoRes.data.userId
-        );
-        this.contactInfo = dynamicsContact.data.value[0];
-      }
       this.userInfo = userInfoRes.data;
+    },
+    async getExternalContact() {
+      const dynamicsContact = await ApiService.getContactByExternalId(
+        this.userInfo.userId
+      );
+      this.contactInfo = dynamicsContact.data.value[0];
     },
     async getEnvironment() {
       const envRes = await ApiService.getEnvironment();


### PR DESCRIPTION
# Main updates
- relocated call to GetExternalUserByID so if it fails, the user can still log into the portal and EOI form will default to use BCeID data